### PR TITLE
Reverted formatting that was breaking the build

### DIFF
--- a/octane-eclipse-plugin/pom.xml
+++ b/octane-eclipse-plugin/pom.xml
@@ -39,10 +39,7 @@
 								</goals>
 								<configuration>
 									<parameters>
-										-g
-										${project.build.directory}/${project.name}-${project.version}.jar
-										-t 24 -p AGN_JAR -i -v -u jarsigner -c 1 -o
-										${project.build.directory}
+										-g ${project.build.directory}/${project.name}-${project.version}.jar -t 24 -p AGN_JAR -i -v -u jarsigner -c 1 -o ${project.build.directory}
 									</parameters>
 									<properties>
 										<krb.account_name>${hpsign.account_name}</krb.account_name>


### PR DESCRIPTION
-g ${project.build.directory}/${project.name}-${project.version}.jar -t 24 -p AGN_JAR -i -v -u jarsigner -c 1 -o ${project.build.directory}

needs to stay one one line