### PR TITLE
Removed rank field from plugin detail view

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityFieldsComposite.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityFieldsComposite.java
@@ -56,7 +56,7 @@ public class EntityFieldsComposite extends Composite {
     private static MetadataService metadataService = Activator.getInstance(MetadataService.class);
     private static FieldEditorFactory fieldEditorFactory = new FieldEditorFactory();
 
-    private Map<String, String> prettyFieldsMap;
+    private Map<String, String> fieldLabelMap;
 
     private EntityModelWrapper entityModel;
 
@@ -140,11 +140,8 @@ public class EntityFieldsComposite extends Composite {
                 .forEach(child -> child.dispose());
 
         // make a map of the field names and labels
-        Collection<FieldMetadata> allFields = metadataService.getVisibleFields(entityModelWrapper.getEntityType());
-        prettyFieldsMap = allFields.stream().collect(Collectors.toMap(FieldMetadata::getName, FieldMetadata::getLabel));
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_DESCRIPTION);
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_PHASE);
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_NAME);
+        Collection<FieldMetadata> fieldMetadata = metadataService.getVisibleFields(entityModelWrapper.getEntityType());
+        fieldLabelMap = fieldMetadata.stream().collect(Collectors.toMap(FieldMetadata::getName, FieldMetadata::getLabel));
 
         fieldsComposite.setLayout(new FillLayout(SWT.HORIZONTAL));
         Composite sectionClientLeft = new Composite(fieldsComposite, SWT.NONE);
@@ -175,7 +172,7 @@ public class EntityFieldsComposite extends Composite {
                     && !fieldName.equals(EntityFieldsConstants.FIELD_PHASE)) {
                 // Add the pair of labels for field and value
                 CLabel labelFieldName = new CLabel(columnComposite, SWT.NONE);
-                labelFieldName.setText(prettyFieldsMap.get(fieldName));
+                labelFieldName.setText(fieldLabelMap.get(fieldName));
                 labelFieldName.setFont(JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT));
                 GridData labelFieldNameGridData = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
                 labelFieldName.setLayoutData(labelFieldNameGridData);

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityHeaderComposite.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityHeaderComposite.java
@@ -68,7 +68,7 @@ public class EntityHeaderComposite extends Composite {
     private static final String TOOLTIP_COMMENTS = "Show comments";
 
     private static MetadataService metadataService = Activator.getInstance(MetadataService.class);
-    private Map<String, String> prettyFieldsMap;
+    private Map<String, String> fieldLabelMap;
     private static final Map<Entity, Set<String>> defaultFields = DefaultEntityFieldsUtil.getDefaultFields();
 
     private ToolTip truncatedLabelTooltip;
@@ -155,7 +155,7 @@ public class EntityHeaderComposite extends Composite {
         fieldCombo = new MultiSelectComboBox<>(new LabelProvider() {
             @Override
             public String getText(Object fieldName) {
-                return prettyFieldsMap.get(fieldName);
+                return fieldLabelMap.get(fieldName);
             }
         });
 
@@ -250,14 +250,17 @@ public class EntityHeaderComposite extends Composite {
         }
 
         // make a map of the field names and labels
-        Collection<FieldMetadata> allFields = metadataService.getVisibleFields(Entity.getEntityType(entityModel));
-        prettyFieldsMap = allFields.stream().collect(Collectors.toMap(FieldMetadata::getName, FieldMetadata::getLabel));
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_DESCRIPTION);
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_PHASE);
-        prettyFieldsMap.remove(EntityFieldsConstants.FIELD_NAME);
+        Collection<FieldMetadata> fieldMetadata = metadataService.getVisibleFields(Entity.getEntityType(entityModel));
+        fieldLabelMap = fieldMetadata.stream().collect(Collectors.toMap(FieldMetadata::getName, FieldMetadata::getLabel));
+        
+        //Hidden fields, plugin UI restriction
+        fieldLabelMap.remove(EntityFieldsConstants.FIELD_DESCRIPTION);
+        fieldLabelMap.remove(EntityFieldsConstants.FIELD_PHASE);
+        fieldLabelMap.remove(EntityFieldsConstants.FIELD_NAME);
+        fieldLabelMap.remove(EntityFieldsConstants.FIELD_RANK);
 
         fieldCombo.clear();
-        fieldCombo.addAll(prettyFieldsMap.keySet());
+        fieldCombo.addAll(fieldLabelMap.keySet());
         fieldCombo.setSelection(PluginPreferenceStorage.getShownEntityFields(Entity.getEntityType(entityModel)), false);
     }
 

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/util/EntityFieldsConstants.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/util/EntityFieldsConstants.java
@@ -71,6 +71,7 @@ public class EntityFieldsConstants {
     public static final String FIELD_ITEM_ORIGIN = "item_origin";
     public static final String FIELD_ESTIMATED_HOURS = "estimated_hours";
     public static final String FIELD_AUTOMATION_STATUS = "automation_status";
+    public static final String FIELD_RANK = "rank";
 
     // inner user prop
     public static final String FIELD_FULL_NAME = "full_name";


### PR DESCRIPTION
Rank field only works if you get more than one entity and sort_by=rank field.
This is how it works in the octane web ui too.
If you don't sort by the rank field, the value will be gibberish.
Since we fetch a single entity for the detail view, the value will never be correct.
Quickfix is removing the rank field from the detail view, since an easy fix is not possible