### PR TITLE
Save in main thread

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -177,20 +177,12 @@ public class EntityModelEditor extends EditorPart {
                 });
                 
                 errorDialog.open(octaneException, "Saving entity failed");
-                
-                //This will stop the window from closing if an error occurs 
-                //when saving from the dialog that appears when you close a dirty tab
-                monitor.setCanceled(true); 
             }
             
         } catch (OperationCanceledException | InterruptedException ignored) {
             EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
             errorDialog.addButton("Back", () -> errorDialog.close());
             errorDialog.open(new OctaneException(new ErrorModel("Save timeout")), "Saving entity failed");
-            
-            //This will stop the window from closing if an error occurs 
-            //when saving from the dialog that appears when you close a dirty tab
-            monitor.setCanceled(true); 
         }
     }
 

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -17,17 +17,15 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.EditorPart;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;
@@ -42,18 +40,17 @@ import com.hpe.octane.ideplugins.eclipse.ui.entitydetail.model.EntityModelWrappe
 import com.hpe.octane.ideplugins.eclipse.ui.util.LoadingComposite;
 import com.hpe.octane.ideplugins.eclipse.ui.util.StackLayoutComposite;
 import com.hpe.octane.ideplugins.eclipse.ui.util.icon.EntityIconFactory;
+import com.hpe.octane.ideplugins.eclipse.ui.util.resource.PlatformResourcesManager;
 import com.hpe.octane.ideplugins.eclipse.ui.util.resource.SWTResourceManager;
 
 public class EntityModelEditor extends EditorPart {
 
-    private static final EntityIconFactory entityIconFactoryForTabInfo = new EntityIconFactory(20, 20, 7);
-    private static EntityService entityService = Activator.getInstance(EntityService.class);
-
-    private static final Color BACKGROUND_COLOR = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme()
-            .getColorRegistry().get(JFacePreferences.CONTENT_ASSIST_BACKGROUND_COLOR);
-
     public static final String ID = "com.hpe.octane.ideplugins.eclipse.ui.entitydetail.EntityModelEditor"; //$NON-NLS-1$
+    private static final EntityIconFactory entityIconFactoryForTabInfo = new EntityIconFactory(20, 20, 7);
+    private static final String SAVE_FAILED_DIALOG_TITLE = "Saving entity failed";
 
+    private static EntityService entityService = Activator.getInstance(EntityService.class);
+    
     public EntityModelEditorInput input;
     private EntityModelWrapper entityModelWrapper;
     private EntityComposite entityComposite;
@@ -81,7 +78,7 @@ public class EntityModelEditor extends EditorPart {
         rootComposite = new StackLayoutComposite(parent, SWT.NONE);
         rootComposite.setBackgroundMode(SWT.INHERIT_FORCE);
         rootComposite.setForeground(SWTResourceManager.getColor(SWT.COLOR_LIST_SELECTION));
-        rootComposite.setBackground(BACKGROUND_COLOR);
+        rootComposite.setBackground(PlatformResourcesManager.getPlatformBackgroundColor());
 
         loadingComposite = new LoadingComposite(rootComposite, SWT.NONE);
         rootComposite.showControl(loadingComposite);
@@ -145,7 +142,7 @@ public class EntityModelEditor extends EditorPart {
     private void setIsDirty(boolean isDirty) {
         Display.getDefault().syncExec(() -> {
             EntityModelEditor.this.isDirty = isDirty;
-            firePropertyChange(PROP_DIRTY);
+            firePropertyChange(IEditorPart.PROP_DIRTY);
         });
     }
 
@@ -159,30 +156,31 @@ public class EntityModelEditor extends EditorPart {
         
         try {
             updateEntityJob.join(1000 * 10, monitor);
-
             OctaneException octaneException = updateEntityJob.getOctaneException();
-            if (octaneException == null) {
-                loadEntity();
-                
+            if (octaneException != null) {
+                throw octaneException;
             } else {
-                EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
-                errorDialog.addButton("Back", () -> errorDialog.close());
-                errorDialog.addButton("Refresh", () -> {
-                    loadEntity();
-                    errorDialog.close();
-                });
-                errorDialog.addButton("Open in browser", () -> {
-                    entityService.openInBrowser(entityModelWrapper.getReadOnlyEntityModel());
-                    errorDialog.close();
-                });
-                
-                errorDialog.open(octaneException, "Saving entity failed");
+                loadEntity(); //reload entity from server if save was successful
             }
-            
-        } catch (OperationCanceledException | InterruptedException ignored) {
+
+        } catch (OperationCanceledException | InterruptedException | OctaneException ex) {
             EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
             errorDialog.addButton("Back", () -> errorDialog.close());
-            errorDialog.open(new OctaneException(new ErrorModel("Save timeout")), "Saving entity failed");
+            errorDialog.addButton("Refresh", () -> {
+                loadEntity();
+                errorDialog.close();
+            });
+            errorDialog.addButton("Open in browser", () -> {
+                entityService.openInBrowser(entityModelWrapper.getReadOnlyEntityModel());
+                errorDialog.close();
+            });
+            
+            if(ex instanceof OperationCanceledException || ex instanceof InterruptedException) {
+                errorDialog.open(new OctaneException(new ErrorModel("Save timeout")), SAVE_FAILED_DIALOG_TITLE);
+            }
+            else if(ex instanceof OctaneException) {
+                errorDialog.open((OctaneException) ex, SAVE_FAILED_DIALOG_TITLE);
+            }
         }
     }
 

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -13,6 +13,7 @@
 package com.hpe.octane.ideplugins.eclipse.ui.entitydetail;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -30,6 +31,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.EditorPart;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;
+import com.hpe.adm.nga.sdk.model.ErrorModel;
 import com.hpe.adm.nga.sdk.model.FieldModel;
 import com.hpe.adm.octane.ideplugins.services.EntityService;
 import com.hpe.octane.ideplugins.eclipse.Activator;
@@ -148,45 +150,48 @@ public class EntityModelEditor extends EditorPart {
     }
 
     @Override
-    public void setFocus() {
-    }
+    public void setFocus() {}
 
     @Override
     public void doSave(IProgressMonitor monitor) {
         UpdateEntityJob updateEntityJob = new UpdateEntityJob("Saving " + entityModelWrapper.getEntityType(), entityModelWrapper.getEntityModel());
-
-        updateEntityJob.addJobChangeListener(new JobChangeAdapter() {
-            @Override
-            public void done(IJobChangeEvent event) {
-                OctaneException octaneException = updateEntityJob.getOctaneException();
-
-                if (octaneException == null) {
-                    loadEntity();
-
-                } else {
-                    Display.getDefault().asyncExec(() -> {
-
-                        EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
-
-                        errorDialog.addButton("Back", () -> errorDialog.close());
-
-                        errorDialog.addButton("Refresh", () -> {
-                            loadEntity();
-                            errorDialog.close();
-                        });
-                        errorDialog.addButton("Open in browser", () -> {
-                            entityService.openInBrowser(entityModelWrapper.getReadOnlyEntityModel());
-                            errorDialog.close();
-                        });
-
-                        errorDialog.open(octaneException, "Saving entity failed");
-
-                    });
-                }
-            }
-        });
-
         updateEntityJob.schedule();
+        
+        try {
+            updateEntityJob.join(1000 * 10, monitor);
+
+            OctaneException octaneException = updateEntityJob.getOctaneException();
+            if (octaneException == null) {
+                loadEntity();
+                
+            } else {
+                EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
+                errorDialog.addButton("Back", () -> errorDialog.close());
+                errorDialog.addButton("Refresh", () -> {
+                    loadEntity();
+                    errorDialog.close();
+                });
+                errorDialog.addButton("Open in browser", () -> {
+                    entityService.openInBrowser(entityModelWrapper.getReadOnlyEntityModel());
+                    errorDialog.close();
+                });
+                
+                errorDialog.open(octaneException, "Saving entity failed");
+                
+                //This will stop the window from closing if an error occurs 
+                //when saving from the dialog that appears when you close a dirty tab
+                monitor.setCanceled(true); 
+            }
+            
+        } catch (OperationCanceledException | InterruptedException ignored) {
+            EntityDetailErrorDialog errorDialog = new EntityDetailErrorDialog(rootComposite.getShell());
+            errorDialog.addButton("Back", () -> errorDialog.close());
+            errorDialog.open(new OctaneException(new ErrorModel("Save timeout")), "Saving entity failed");
+            
+            //This will stop the window from closing if an error occurs 
+            //when saving from the dialog that appears when you close a dirty tab
+            monitor.setCanceled(true); 
+        }
     }
 
     @Override
@@ -203,4 +208,6 @@ public class EntityModelEditor extends EditorPart {
     public boolean isSaveAsAllowed() {
         return entityModelWrapper != null && isDirty;
     }
+
+
 }

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -208,6 +208,4 @@ public class EntityModelEditor extends EditorPart {
     public boolean isSaveAsAllowed() {
         return entityModelWrapper != null && isDirty;
     }
-
-
 }

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -181,6 +181,14 @@ public class EntityModelEditor extends EditorPart {
             else if(ex instanceof OctaneException) {
                 errorDialog.open((OctaneException) ex, SAVE_FAILED_DIALOG_TITLE);
             }
+            
+            // This would stop the editor from closing, if the editor was being closed before the save
+            // The monitor can be null because of doSaveAs()
+            // The monitor being null will not affect the editor b4 close, 
+            // because when the platform saves b4 close, it will always use the doSave method, i. e. the monitor won't be null
+            if(monitor != null) {
+                monitor.setCanceled(true);
+            }
         }
     }
 


### PR DESCRIPTION
doSave() method now locks the UI thread. Has a 10 second timeout.

This is needed for the save before close dialog to work.
If the save method would not block, the editor would close before save operation would finish