### PR TITLE
defect #717032: creates rectangle image labels

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitydetail/EntityModelEditor.java
@@ -70,7 +70,7 @@ public class EntityModelEditor extends EditorPart {
         setInput(input);
         
         setPartName(String.valueOf(this.input.getId()));
-        setTitleImage(EntityIconFactory.getInstance().getImageForEditorPart(this.input.getEntityType(), 25, 8));
+        setTitleImage(EntityIconFactory.getInstance().getImageForEditorPart(this.input.getEntityType(), 17, 7));
     }
 
     @Override

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/mywork/MyWorkEntityModelMenuFactory.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/mywork/MyWorkEntityModelMenuFactory.java
@@ -172,7 +172,7 @@ public class MyWorkEntityModelMenuFactory implements EntityModelMenuFactory {
                 addMenuItem(menu,
                         "View parent details",
 
-                        EntityIconFactory.getInstance().getImageIcon(Entity.getEntityType(parentEntityModel), 25, 8), () -> {
+                        EntityIconFactory.getInstance().getImageForEditorPart(Entity.getEntityType(parentEntityModel), 25, 8), () -> {
                             Integer parentId = Integer.valueOf(parentEntityModel.getValue("id").getValue().toString());
                             Entity parentEntityType = Entity.getEntityType(parentEntityModel);
                             if (Entity.FEATURE == Entity.getEntityType(parentEntityModel) || Entity.EPIC == Entity.getEntityType(parentEntityModel)) {

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/mywork/MyWorkEntityModelMenuFactory.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/mywork/MyWorkEntityModelMenuFactory.java
@@ -154,7 +154,7 @@ public class MyWorkEntityModelMenuFactory implements EntityModelMenuFactory {
             addMenuItem(
                     menu,
                     "View details",
-                    EntityIconFactory.getInstance().getImageForEditorPart(entityType, 17, 6),
+                    EntityIconFactory.getInstance().getImageForEditorPart(entityType, 17, 7),
                     () -> openDetailTab(entityId, entityType));
         }
 
@@ -172,7 +172,7 @@ public class MyWorkEntityModelMenuFactory implements EntityModelMenuFactory {
                 addMenuItem(menu,
                         "View parent details",
 
-                        EntityIconFactory.getInstance().getImageForEditorPart(Entity.getEntityType(parentEntityModel), 25, 8), () -> {
+                        EntityIconFactory.getInstance().getImageForEditorPart(Entity.getEntityType(parentEntityModel), 17, 7), () -> {
                             Integer parentId = Integer.valueOf(parentEntityModel.getValue("id").getValue().toString());
                             Entity parentEntityType = Entity.getEntityType(parentEntityModel);
                             if (Entity.FEATURE == Entity.getEntityType(parentEntityModel) || Entity.EPIC == Entity.getEntityType(parentEntityModel)) {

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/search/SearchEntityModelMenuFactory.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/search/SearchEntityModelMenuFactory.java
@@ -120,7 +120,7 @@ public class SearchEntityModelMenuFactory implements EntityModelMenuFactory {
             addMenuItem(
                     menu,
                     "View details",
-                    EntityIconFactory.getInstance().getImageIcon(entityType, 16, 7),
+                    EntityIconFactory.getInstance().getImageForEditorPart(entityType, 16, 7),
                     () -> openDetailTab(entityId, entityType));
         }
 


### PR DESCRIPTION
for places where we need to integrate with the editor

adds cache for the images for the editors
creates rectangle images for view parent details and view details of 
searched items