### PR TITLE
Performance issues investigation

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitylist/custom/AbsoluteLayoutEntityListViewer.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/entitylist/custom/AbsoluteLayoutEntityListViewer.java
@@ -278,7 +278,6 @@ public class AbsoluteLayoutEntityListViewer extends ScrolledComposite implements
             
             if(event.count == 2) {
             	changeSelection(-1);
-            	forceRedrawRows();
             }
             // Fire listeners
             MouseEvent mouseEvent = new MouseEvent(event);
@@ -287,7 +286,6 @@ public class AbsoluteLayoutEntityListViewer extends ScrolledComposite implements
             }
         } else {
             changeSelection(-1);
-            forceRedrawRows();
         }
 
     }


### PR DESCRIPTION
- fix for loading composite background thread going forever - now stops when loading no longer visible
(slight performance boost but not what we were looking for)
- real performance improvement came from taking out force redraw from mouse events, every time a mouse event was captured the entity model rows were redrawn -> their children were dedrawn -> their childrens children and so on were redrawn since the method was recursive.
* fix involves calling the forceredraw only when setting the active item
 