### PR TITLE
defect #11711031: Fix search for older versions of octane

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/search/SearchJob.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/search/SearchJob.java
@@ -32,11 +32,13 @@ public class SearchJob extends Job {
     private boolean isCancelled = false;
     private EntityListData resultEntityListData;
     private String query;
+    private Entity[] searchEntityTypes;
 
-    public SearchJob(String name, String query, EntityListData resultEntityListData) {
+    public SearchJob(String name, String query, EntityListData resultEntityListData, Entity... searchEntityTypes) {
         super(name);
         this.resultEntityListData = resultEntityListData;
         this.query = query;
+        this.searchEntityTypes = searchEntityTypes;
     }
 
     @Override
@@ -50,7 +52,7 @@ public class SearchJob extends Job {
         Collection<EntityModel> searchResults = searchService.searchGlobal(
                 query,
                 20,
-                SearchEditor.searchEntityTypes.toArray(new Entity[] {}));
+                this.searchEntityTypes);
 
         if (!isCancelled) {
             Display.getDefault().asyncExec(() -> {


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=11711031

**PROBLEM**
The plugin throws error and the search does not work if the Octane server version is older.

**SOLUTION**
Added the BDD to searchEntityTypes array if the octane version is higher or equal than 15.1.4, before using the array, so it won't send wrong request to server.