### PR TITLE
defect #1443005: make RF comment open in browser by double clicking

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/util/OpenDetailTabEntityMouseListener.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/util/OpenDetailTabEntityMouseListener.java
@@ -55,29 +55,29 @@ public class OpenDetailTabEntityMouseListener implements EntityMouseListener {
             if (Entity.COMMENT == Entity.getEntityType(entityModel)) {
                 entityModel = (EntityModel) Util.getContainerItemForCommentModel(entityModel).getValue();
             }
-    		
-			Set<Entity> openInBrowserEntities = new LinkedHashSet<>(Arrays.asList(
-		            Entity.EPIC,
-		            Entity.FEATURE,
-		            Entity.AUTOMATED_TEST,
-		            Entity.AUTOMATED_TEST_RUN,
-		            Entity.BDD_SCENARIO,
-					Entity.REQUIREMENT_FOLDER));
-		    
-		    if(openInBrowserEntities.contains(Entity.getEntityType(entityModel))) {
-            	entityService.openInBrowser(entityModel);
+
+            Set<Entity> openInBrowserEntities = new LinkedHashSet<>(Arrays.asList(
+                    Entity.EPIC,
+                    Entity.FEATURE,
+                    Entity.AUTOMATED_TEST,
+                    Entity.AUTOMATED_TEST_RUN,
+                    Entity.BDD_SCENARIO,
+                    Entity.REQUIREMENT_FOLDER));
+
+            if (openInBrowserEntities.contains(Entity.getEntityType(entityModel))) {
+                entityService.openInBrowser(entityModel);
             } else {
-	            Long id = Long.parseLong(entityModel.getValue("id").getValue().toString());
-	            EntityModelEditorInput entityModelEditorInput = new EntityModelEditorInput(id, Entity.getEntityType(entityModel));
-	            try {
-	                logger.log(new Status(Status.INFO, Activator.PLUGIN_ID, Status.OK, entityModelEditorInput.toString(), null));                
-	                page.openEditor(entityModelEditorInput, EntityModelEditor.ID);                                      
-	            } catch (PartInitException ex) {
-	                logger.log(
-	                        new Status(Status.ERROR, Activator.PLUGIN_ID, Status.ERROR, "An exception has occured when opening the editor", ex));
-	            }
+                Long id = Long.parseLong(entityModel.getValue("id").getValue().toString());
+                EntityModelEditorInput entityModelEditorInput = new EntityModelEditorInput(id, Entity.getEntityType(entityModel));
+                try {
+                    logger.log(new Status(Status.INFO, Activator.PLUGIN_ID, Status.OK, entityModelEditorInput.toString(), null));
+                    page.openEditor(entityModelEditorInput, EntityModelEditor.ID);
+                } catch (PartInitException ex) {
+                    logger.log(
+                            new Status(Status.ERROR, Activator.PLUGIN_ID, Status.ERROR, "An exception has occured when opening the editor", ex));
+                }
             }
-            
+
         }
     }
 

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/util/OpenDetailTabEntityMouseListener.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/ui/util/OpenDetailTabEntityMouseListener.java
@@ -61,7 +61,8 @@ public class OpenDetailTabEntityMouseListener implements EntityMouseListener {
 		            Entity.FEATURE,
 		            Entity.AUTOMATED_TEST,
 		            Entity.AUTOMATED_TEST_RUN,
-		            Entity.BDD_SCENARIO));
+		            Entity.BDD_SCENARIO,
+					Entity.REQUIREMENT_FOLDER));
 		    
 		    if(openInBrowserEntities.contains(Entity.getEntityType(entityModel))) {
             	entityService.openInBrowser(entityModel);


### PR DESCRIPTION
**Problem:** double clicking on RF comment would've pop an error by trying to open it in detailed view

![image](https://user-images.githubusercontent.com/42770621/147112964-bbc804ec-472d-477f-a72a-feb41bd2ae4c.png)

**Solution:** make the RF comment parent entity open in browser by default on double-click