### PR TITLE
Tzapirtan story 1934089 update java sdk eclipse

### DIFF
--- a/octane-eclipse-feature/feature.xml
+++ b/octane-eclipse-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="octane.eclipse.feature"
       label="ALM Octane IDE Integration"
-      version="2022.0.0"
+      version="2022.1.0"
       provider-name="Micro Focus">
 
    <description url="https://software.microfocus.com/en-us/products/alm-octane/overview">

--- a/octane-eclipse-feature/pom.xml
+++ b/octane-eclipse-feature/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>..</relativePath>
 		<groupId>com.hpe.adm.octane.ideplugins</groupId>
 		<artifactId>octane-eclipse-parent</artifactId>
-		<version>2022.0.0</version>
+		<version>2022.1.0</version>
 	</parent>
 	<artifactId>octane.eclipse.feature</artifactId>
 	<packaging>eclipse-feature</packaging>

--- a/octane-eclipse-plugin/.classpath
+++ b/octane-eclipse-plugin/.classpath
@@ -7,11 +7,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/opencensus-contrib-http-util.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/octane-plugin-common.jar" sourcepath="/octane-plugin-common"/>
 	<classpathentry kind="lib" path="lib/slf4j-api.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/aopalliance.jar"/>

--- a/octane-eclipse-plugin/.classpath
+++ b/octane-eclipse-plugin/.classpath
@@ -7,7 +7,11 @@
 	<classpathentry exported="true" kind="lib" path="lib/opencensus-contrib-http-util.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/octane-plugin-common.jar" sourcepath="/octane-plugin-common"/>
 	<classpathentry kind="lib" path="lib/slf4j-api.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/aopalliance.jar"/>
@@ -15,13 +19,9 @@
 	<classpathentry exported="true" kind="lib" path="lib/commons-collections.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-lang.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-logging.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/google-api-client-gson.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/google-api-client-jackson2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/google-api-client.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/google-http-client-gson.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/google-http-client-jackson2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/google-http-client.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/google-oauth-client.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/gson.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/guava.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/guice.jar"/>

--- a/octane-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/octane-eclipse-plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ALM Octane IDE Plugin
 Bundle-SymbolicName: octane.eclipse.plugin;singleton:=true
-Bundle-Version: 2022.0.0
+Bundle-Version: 2022.1.0
 Bundle-Vendor: Micro Focus
 Bundle-Activator: com.hpe.octane.ideplugins.eclipse.Activator
 Require-Bundle: org.eclipse.core.runtime,
@@ -29,13 +29,9 @@ Bundle-ClassPath: .,
  lib/commons-collections.jar,
  lib/commons-lang.jar,
  lib/commons-logging.jar,
- lib/google-api-client-gson.jar,
- lib/google-api-client-jackson2.jar,
- lib/google-api-client.jar,
  lib/google-http-client-gson.jar,
  lib/google-http-client-jackson2.jar,
  lib/google-http-client.jar,
- lib/google-oauth-client.jar,
  lib/gson.jar,
  lib/guava.jar,
  lib/guice.jar,

--- a/octane-eclipse-plugin/build.properties
+++ b/octane-eclipse-plugin/build.properties
@@ -10,13 +10,9 @@ bin.includes = plugin.xml,\
                lib/commons-collections.jar,\
                lib/commons-lang.jar,\
                lib/commons-logging.jar,\
-               lib/google-api-client-gson.jar,\
-               lib/google-api-client-jackson2.jar,\
-               lib/google-api-client.jar,\
                lib/google-http-client-gson.jar,\
                lib/google-http-client-jackson2.jar,\
                lib/google-http-client.jar,\
-               lib/google-oauth-client.jar,\
                lib/gson.jar,\
                lib/guava.jar,\
                lib/guice.jar,\

--- a/octane-eclipse-plugin/pom.xml
+++ b/octane-eclipse-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.hpe.adm.octane.ideplugins</groupId>
 		<artifactId>octane-eclipse-parent</artifactId>
-		<version>2022.0.0</version>
+		<version>2022.1.0</version>
 	</parent>
 	<artifactId>octane.eclipse.plugin</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/Activator.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/Activator.java
@@ -35,7 +35,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
-import com.hpe.adm.nga.sdk.authentication.Authentication;
+import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;
 import com.hpe.adm.octane.ideplugins.services.connection.BasicConnectionSettingProvider;
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;
 import com.hpe.adm.octane.ideplugins.services.connection.HttpClientProvider;
@@ -154,7 +154,7 @@ public class Activator extends AbstractUIPlugin {
                 settingsProviderInstance.setConnectionSettings(new ConnectionSettings());
             } else {
 
-                Authentication authentication;
+                JSONAuthentication authentication;
 
                 if (Boolean.parseBoolean(isBrowserAuth)) {
                     authentication = new GrantTokenAuthentication();

--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/preferences/PluginPreferencePage.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/preferences/PluginPreferencePage.java
@@ -428,7 +428,7 @@ public class PluginPreferencePage extends PreferencePage implements IWorkbenchPr
             UserAuthentication userAuthentication = (UserAuthentication) newConnectionSettings.getAuthentication();
 
             try {
-                validateUsernameAndPassword(userAuthentication.getUserName(), userAuthentication.getPassword());
+                validateUsernameAndPassword(userAuthentication.getAuthenticationId(), userAuthentication.getAuthenticationSecret());
             } catch (ServiceException e) {
                 setConnectionStatus(false, e.getMessage());
                 return null;

--- a/octane-eclipse-update-site/pom.xml
+++ b/octane-eclipse-update-site/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>..</relativePath>
 		<groupId>com.hpe.adm.octane.ideplugins</groupId>
 		<artifactId>octane-eclipse-parent</artifactId>
-		<version>2022.0.0</version>
+		<version>2022.1.0</version>
 	</parent>
 	<artifactId>octane-eclispse-update-site</artifactId>
 	<packaging>eclipse-update-site</packaging>

--- a/octane-eclipse-update-site/site.xml
+++ b/octane-eclipse-update-site/site.xml
@@ -3,7 +3,7 @@
    <description name="ALM Octane IDE Integration Update Site" url="http://microfocus.github.io/octane-eclipse-plugin/update-site/">
       Install the latest verison of the ALM Octane IDE Integration
    </description>
-   <feature url="features/octane.eclipse.feature_2022.0.0.jar" id="octane.eclipse.feature" version="2022.0.0">
+   <feature url="features/octane.eclipse.feature_2022.1.0.jar" id="octane.eclipse.feature" version="2022.1.0">
       <category name="alm.octane"/>
    </feature>
    <category-def name="alm.octane" label="ALM Octane"/>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.hpe.adm.octane.ideplugins</groupId>
 	<artifactId>octane-eclipse-parent</artifactId>
-	<version>2022.0.0</version>
+	<version>2022.1.0</version>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -20,7 +20,7 @@
 		<logback.version>1.2.9</logback.version>
 
 		<tycho-version>1.7.0</tycho-version>
-		<octane.common.version>1.7.2</octane.common.version>
+		<octane.common.version>1.8.0-SNAPSHOT</octane.common.version>
 		<java.version>11</java.version>
 		<signhp.version>15.0</signhp.version>
 		<sign-hp-utility.version>1.0.5</sign-hp-utility.version>


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=1934089
Story is about updating the sdk version from 12.60.60 to 16.0.400.1

Changes include:
* updating common module to 1.8.0-SNAPSHOT (this includes sdk 16.0.400.1)
* removal of 4 libraries that were used in the previous sdk but are not used anymore
* resolved inconsistencies between new sdk and eclipse plugin code
* updating version of eclipse plugin to 2022.1.0