### PR TITLE
defect #2411003: added full commit message when copying to clipboard

### DIFF
--- a/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/util/CommitMessageUtil.java
+++ b/octane-eclipse-plugin/src/com/hpe/octane/ideplugins/eclipse/util/CommitMessageUtil.java
@@ -89,7 +89,8 @@ public class CommitMessageUtil {
                 } else {
                     activeEntityModel = currentItem.toEntityModel();
                 }
-                String commitMessage = generateClientSideCommitMessage(activeEntityModel);
+                Boolean isTaskParent = false;
+                String commitMessage = generateClientSideCommitMessage(activeEntityModel, isTaskParent);
 
                 // Validate against server side patterns, since generation based
                 // on a regex with no params is not possible
@@ -158,17 +159,21 @@ public class CommitMessageUtil {
     /*
      * Task requires story field to be loaded
      */
-    private static String generateClientSideCommitMessage(EntityModel entityModel) {
+	private static String generateClientSideCommitMessage(EntityModel entityModel, Boolean isTaskParent) {
 
         StringBuilder messageBuilder = new StringBuilder();
 
         String entityId = String.valueOf(entityModel.getValue("id").getValue());
+        
+        String commitMessage = "my commit message";
 
         if (Entity.TASK == Entity.getEntityType(entityModel)) {
+        	
             // Tasks include parent commit message info
             EntityModel taskParent = ((ReferenceFieldModel) entityModel.getValue("story")).getValue();
+           
             messageBuilder
-                    .append(generateClientSideCommitMessage(taskParent));
+                    .append(generateClientSideCommitMessage(taskParent, true));
         }
 
         messageBuilder
@@ -176,6 +181,10 @@ public class CommitMessageUtil {
                 .append(" #")
                 .append(entityId)
                 .append(": ");
+        
+        if (!isTaskParent) {
+        	messageBuilder.append(commitMessage);
+        }
 
         return messageBuilder.toString();
     }


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411003](https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411003)

**Problem:** When user tries to copy commit message to clipboard it will be only copied as "defect #1234", instead of "defect #1234: my commit message".

**Solution:**  I added a new parameter to the method that generates commit message in order to know if we need to generate a message for a task which has a task parent (i.e. user story #1234: task #1234: my commit message). Using the new added parameter we know if the method is invoked for a task parent and we do not add the commit message. We add "my commit message" text only at the final of full message.